### PR TITLE
[WIP] Installation Documentation Updates for New users

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -3,9 +3,11 @@ Installation
 
 Before you start, make sure your system has the following packages installed,
 
-- gdal (libgdal-dev)
+- gdal (libgdal-dev version >= 2.0.0)
 - openmpi
 - hdf5
+
+libgdal-dev version 2.0.0 or higher is required to build the required GDAL python package. For Ubuntu, binaries for version 2.0.0 and higher can be found in PPA https://wiki.ubuntu.com/UbuntuGIS.  
 
 We **strongly** recommend using a virtual environment.
 To install, simply run ``setup.py``:


### PR DESCRIPTION
Installation instructions need a general update.  For new users installation should be simplified and more testing should be added to make sure everything is running correctly. Currently these are the points I noticed during and after the installation that need to be addressed:

- [ ] pbs/README.md  needs to be updated. Current version ends up with compilation errors due to missing dependencies.  

    - [ ] **pip3** that comes with python 3.4.3 in NCI can't find the requirement **catboost==0.3.0** . So current version of uncover-ml is not compatible with python 3.4.3.  Dependency on catboost 0.3.0 should be updated to newer versions or NCI instructions should be limited to Python 2.7.11 with pip which can find catboost 0.3.0

    - [ ] Default compiler version of **gcc** in NCI can't compile the required version of xgboost due to C++11 issues. More instructions should be added to use a newer version of **gcc**. 

    - [ ] submit_tests.sh can't be found. More user friendly test script is needed to test if everything is working in NCI. 

    - [ ] submit_murray_* and submit_sirsam_* scripts require an update. First the required data for this splits either should be supplied or should be put in a public directory for easy testing for new users. Secondly they should be updated to use the latest version of uncover-ml.

- [ ] **makecubist** uses **realpath** function which is not available for all users, for example NCI doesn't have realpath function. Either this needs to be specified as a requirement or **makecubist** should be updated accordingly.

- [ ] Jupyter notebooks under the folder notebooks should be updated. More simple notebooks that show simple usage of uncover-ml can be added for new users.

- [x] docs/installation.rst   My last commit fixes an issue related to libgdal version required to install uncover-ml. libgdal-dev version>= 2.0.0 is required to successfully compile python package requirement of GDAL.

More points can be added as they are found.

