### PR TITLE
Fix covariate transforms for targetsearch

### DIFF
--- a/uncoverml/scripts/targetsearch_cli.py
+++ b/uncoverml/scripts/targetsearch_cli.py
@@ -117,8 +117,8 @@ def main(config_file, partitions):
         obs = (targets_all.fields[ORIGINAL_OBSERVATIONS][real_ind])[threshold_ind]
         fields = {k: (v[real_ind])[threshold_ind] for k, v in targets_all.fields.items()}
         result_t = ls.targets.Targets(pos, obs, fields)
-        result_x = (x_all[real_ind])[threshold_ind]
+        # result_x = (x_all[real_ind])[threshold_ind]
         # And save as binary for reuse in learn step
         with open(config.targetsearch_result_data, 'wb') as f:
-            pickle.dump((result_t, result_x), f) 
+            pickle.dump(result_t, f) 
         _logger.info(f"Target search complete. Found {len(pos)} targets for inclusion.")


### PR DESCRIPTION
Previous behaviour was to save intersected covariate/target data
after targetsearch and load it in the learn step after the provided
targets/covariates had been intersected and covariates transformed,
and append the data to the end of that.

This is incorrect as we should be intersecting the data and performing
transforms on the full set of data (provided shapefile + targets from
targetsearch).

So new behaviour is to only save targets from targetsearch (not
covariate data as well - not sure why I did that. Probably thought I was
clever by not having to repeat the transform), load them in learn
and merge them with shapefile targets, and then intersect with
covariates and apply transforms.